### PR TITLE
Change container networking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,16 +10,16 @@ services:
     volumes:
       - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
     networks:
-      default:
-        ipv4_address: 172.16.241.10
+      - log
+      - web
+      - fpm
 
   syslog:
     image: balabit/syslog-ng
     volumes:
       - ./syslog-ng.conf:/etc/syslog-ng/syslog-ng.conf
     networks:
-      default:
-        ipv4_address: 172.16.241.12
+      - log
 
   web1:
     image: nginx
@@ -27,8 +27,7 @@ services:
       - ./html:/usr/share/nginx/html
       - ./nginx-www.conf:/etc/nginx/conf.d/default.conf
     networks:
-      default:
-        ipv4_address: 172.16.241.21
+      - web
 
   web2:
     image: nginx
@@ -36,8 +35,7 @@ services:
       - ./html:/usr/share/nginx/html
       - ./nginx-www.conf:/etc/nginx/conf.d/default.conf
     networks:
-      default:
-        ipv4_address: 172.16.241.22
+      - web
 
   php1:
     image: php:7-fpm
@@ -45,8 +43,7 @@ services:
       - ./html:/var/www/html
       - ./php-ping.conf:/usr/local/etc/php-fpm.d/ping.conf
     networks:
-      default:
-        ipv4_address: 172.16.241.31
+      - fpm
 
   php2:
     image: php:7-fpm
@@ -54,13 +51,10 @@ services:
       - ./html:/var/www/html
       - ./php-ping.conf:/usr/local/etc/php-fpm.d/ping.conf
     networks:
-      default:
-        ipv4_address: 172.16.241.32
+      - fpm
 
 networks:
-  default:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 172.16.241.0/24
+  fpm:
+  web:
+  log:
+


### PR DESCRIPTION
You don't need to define static IPs for containers - they can resolve each other by name just fine.

I've also set up different networks for web backends (nginx), FPM and log server.